### PR TITLE
Fix bug: not dealwith const void *

### DIFF
--- a/pkg/dump/code/tracepoint.go
+++ b/pkg/dump/code/tracepoint.go
@@ -33,7 +33,7 @@ func getSkbOffsetOnTracepoint(title string, name string) (int, error) {
 
 	arr := strings.Split(str, "\n")
 
-	mode := `\s*field:void\s+\*\s+skbaddr;\s+offset:(\d+);`
+    mode := `\s*field:(const\s+)*void\s+\*\s+skbaddr;\s+offset:(\d+);`
 
 	reg := regexp.MustCompile(mode)
 
@@ -43,7 +43,7 @@ func getSkbOffsetOnTracepoint(title string, name string) (int, error) {
 		if len(match) <= 1 {
 			continue
 		}
-		return strconv.Atoi(match[1])
+        return strconv.Atoi(match[len(match)-1])
 	}
 
 	return 0, fmt.Errorf("tracepoint does not has skb param: %s", path)


### PR DESCRIPTION
 centos7 with linux kernel 6.1

build netcap and trace tcp_bad_csum, it report like this below
 `/netcap skb -f tracepoint:tcp:tcp_bad_csum  -i any
2024/10/20 15:28:24 Dump err: tracepoint does not has skb param: /sys/kernel/debug/tracing/events/tcp/tcp_bad_csum/format`