### PR TITLE
🐞 fix(netcap tcpdump proxy): Fix bug

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,10 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +40,19 @@ func Execute() {
 	cobra.CheckErr(rootCmd.Execute())
 }
 
-func init() {
+// Process the SIGINT signal, the program will print the stderr if the program receive the SIGINT.
+// So, it should be exit with no err messages.
+func SignalProcess() {
+	stopChan := make(chan struct{}, 1)
+	signalChan := make(chan os.Signal, 1)
+	go func() {
+		<-signalChan
+		stopChan <- struct{}{}
+		os.Exit(0)
+	}()
+	signal.Notify(signalChan, syscall.SIGINT)
+}
 
+func init() {
+	SignalProcess()
 }

--- a/pkg/dump/driver/output/tcpdump_proxy.go
+++ b/pkg/dump/driver/output/tcpdump_proxy.go
@@ -16,7 +16,9 @@ limitations under the License.
 package output
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 )
@@ -41,7 +43,6 @@ func newTcpdumpProxy(out *os.File, flags string) tcpdumpProxy {
 
 	s.cmd.Stdin = r1
 	s.cmd.Stdout = out
-
 	s.inputFile = w1
 
 	go s.run()
@@ -54,8 +55,13 @@ func (s *tcpdumpProxyImpl) GetInput() *os.File {
 }
 
 func (s *tcpdumpProxyImpl) run() {
+	var (
+		stdErr bytes.Buffer
+	)
+	s.cmd.Stderr = &stdErr
 	err := s.cmd.Run()
 	if err != nil {
+		log.Fatalf("cmd run failed:%s,%s\n", stdErr.String(), err.Error())
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
1.fix the program does not print any errors if the tcpdump not be installed.
2.process the SIGINT signal if using ctrl+c command