### PR TITLE
🐞 fix (tcpudmp filter code generate):

### DIFF
--- a/pkg/dump/code/code.go
+++ b/pkg/dump/code/code.go
@@ -102,6 +102,7 @@ func (s *baseCodeImpl) baseGenerate(opt *Option) error {
 		if err != nil {
 			return err
 		}
+		s.tcpdumpFilterCode += "\n"
 		s.compileFlags = append(s.compileFlags, "-DENABLE_FILTER")
 	} else {
 		s.tcpdumpFilterCode = ""


### PR DESCRIPTION
add "\n" on the end of c-filter-function.